### PR TITLE
fix: Issue where there is only a single handler breaks

### DIFF
--- a/src/instance/methods.js
+++ b/src/instance/methods.js
@@ -143,7 +143,7 @@ Moon.prototype.emit = function(eventName, customMeta) {
   meta.type = eventName;
 
   // Get handlers and global handlers
-  let handlers = this.events[eventName];
+  let handlers = [].concat(this.events[eventName]);
   let globalHandlers = this.events['*'];
 
   // Counter


### PR DESCRIPTION
This just casts handlers to an array so that the looping and invoking
always works