### PR TITLE
Add jsDelivr links

### DIFF
--- a/docs/installation.html
+++ b/docs/installation.html
@@ -70,9 +70,13 @@
 <p>Installing Moon is as easy as including a script tag to a CDN. The preferred CDN is <a href="https://unpkg.com">unpkg</a>:</p>
 <pre><code class="lang-html">&lt;!-- Production Build --&gt;
 &lt;script src=&quot;https://unpkg.com/moonjs&quot;&gt;&lt;/script&gt;
+&lt;!-- or --&gt;
+&lt;script src="https://cdn.jsdelivr.net/npm/moonjs@0.11.0/dist/moon.js"&gt;&lt;/script&gt;
 
 &lt;!-- Development Build --&gt;
 &lt;script src=&quot;https://unpkg.com/moonjs/dist/moon.js&quot;&gt;&lt;/script&gt;
+&lt;!-- or --&gt;
+&lt;script src="https://cdn.jsdelivr.net/npm/moonjs@0.11.0/dist/moon.min.js"&gt;&lt;/script&gt;
 </code></pre>
 <h4 id="npm">NPM</h4>
 <p>Moon is supported in Node environments, but to actually update/patch elements, it requires the DOM.</p>


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/moonjs) to your site, because it is the [fastest opensource CDN](https://www.cdnperf.com/) available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg. This PR adds it to the readme as an alternative to unpkg.