### PR TITLE
Add CDNJS version badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
   <a href="https://travis-ci.org/kbrsh/moon"><img src="https://travis-ci.org/kbrsh/moon.svg?branch=master" alt="Build Status"></a>
   <a href="https://codecov.io/gh/kbrsh/moon"><img src="https://codecov.io/gh/kbrsh/moon/branch/master/graph/badge.svg" alt="Code Coverage"></a>
   <a href="https://moon-slack.herokuapp.com"><img src="https://moon-slack.herokuapp.com/badge.svg" alt="Slack"></a>
-  <a href="https://kbrsh.github.io/license"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+  <a href="https://kbrsh.github.io/license"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+  <a href="https://cdnjs.com/libraries/moonjs"><img src="https://img.shields.io/cdnjs/v/moonjs.svg" alt="CDNJS "></a>
 </p>
 <p align="center">
   <a href="https://saucelabs.com/u/KingPixil"><img src="https://saucelabs.com/browser-matrix/KingPixil.svg" alt="Browser Support"></a>


### PR DESCRIPTION
The badge shows the latest lib version on CDNJS and gives a link of it.