### PR TITLE
Update API docs

### DIFF
--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -2,6 +2,61 @@
 title: Instance Methods
 ---
 
+##### **constructor**
+
+- Arguments:
+  - `{Object} options`
+
+The `options` object is defined as follows:
+
+- Properties:
+  - `{String} root`: DOM identifier to find the element in which to set the insance to. It uses `document.querySelector` to get the desired element.
+  - `{String} name`: some name for the app. Defaults to `Root`.
+  - `{Object|Function} data`: the data used by instance. Can be accessed via `{{mustache}}` notation and is reactive. If a function is used, it must return an object with the properties such as an normal `data` object. Defaults to `{}`.
+  - `{Object} methods`: methods of the instance. These can be called via `instance.methods.yourMethod(param)`. `this`, inside these methods, refers to the instance itself. So you can use it to access data using `this.get('someVar')`. Defaults to `{}`.
+  - `{Object} computed`: computed properties of the instance. Every object defined inside this one must have, at least, a `get` or `set` function. The `get` will return some value, depending on some function defined condition. And the `set` receive the value to be set. These can also be accessed via `{{mustache}}` notation and are reactive. No effect if `undefined`.
+  - `{Object} hooks`: hooks for use during the lifecycle of the instance. All of them must be functions. Defaults to `{}`.
+  - `{Function} render`: custom render functions. Defaults to a `noop` function.
+
+All of them can be later accessed by their names via `insance.option` (except for the `render` property, which can be acessed via `instance.compiledRender`).
+
+Usage:
+```js
+const options = {
+  root: "#app", // it can be a '.class' or even 'div'
+  data: {
+    text: "Counter: ",
+    counter: 0
+  },
+  methods: {
+    // call via 'app.methods.toText()''
+    toText: function() {
+      return this.data.toString();
+    }
+  },
+  // threated same way as normal data: "app.get('someComp')"
+  computed: {
+    someComp: {
+      get: function() {
+        return this.get("counter");
+      },
+      set: function(val) {
+        if(val > 10) {
+          this.set("counter", val);
+        }
+      }
+    }
+  },
+  hooks: {
+    mounted: function() {
+      this.set("counter", 10);
+    }
+  }
+};
+
+const app = new Moon(options);
+```
+
 Every Moon instance comes with built in methods specific to that instance, you can call them like: `instance.foo`.
 
 ##### **get**
@@ -12,7 +67,7 @@ Every Moon instance comes with built in methods specific to that instance, you c
 
 Usage:
 ```js
-instance.get('property').foo.bar;
+instance.get("property").foo.bar;
 ```
 
 Can return a value from Moon instance data.
@@ -22,26 +77,19 @@ Can return a value from Moon instance data.
 - Arguments:
   - `{String} keypath`
   - `{Any} value`
+  - `{Object} [obj]`
 
 Usage:
 ```js
-instance.set('property.foo.bar', 'baz');
+instance.set("foo", "baz");
+// Shallow merge with data and notifies observer
+instance.set({
+  foo: true,
+  bar: [1, 2, 3]
+});
 ```
 
-Used to set Moon instance data, ensuring that a DOM build is queued.
-
-##### **callMethod**
-
-- Arguments:
-  - `{String} method`
-  - `{Array} params` (optional)
-
-Usage:
-```js
-instance.callMethod('foo', ['bar', 10]);
-```
-
-Used to call a method defined in the `methods` option of a Moon instance with the provided parameters. It should always be used to call a method manually, as `this` will refer to the Moon instance.
+Used to set Moon instance data, ensuring that a DOM build is queued. If an object is used, it will set the properties based on the key values.
 
 ##### **mount**
 
@@ -51,7 +99,7 @@ Used to call a method defined in the `methods` option of a Moon instance with th
 Usage:
 ```js
 instance.mount("#app");
-instance.mount(el);
+instance.mount(root);
 ```
 
 Used to manually mount an instance to an element, compiling a template or using a render function, and running the initial build.
@@ -125,6 +173,6 @@ Used to emit an event, invoking all current event listeners for that specific ev
 
 ```js
 {
-  type: 'foo' // event name
+  type: "foo" // event name
 }
 ```


### PR DESCRIPTION
category: docs

- Added reference entry for the constructor of instance;
- Added in-depth explanation of the options object used in the
constructor;
- Added example for the constructor;
- Changed some single quotes to double quotes in some examples to match
convention used in the code;
- Removed callMethod from docs;
- Added object use case of instance.set.