### PR TITLE
add tests for multiple HTTP requests

### DIFF
--- a/packages/moon/test/executor/http.test.js
+++ b/packages/moon/test/executor/http.test.js
@@ -151,3 +151,73 @@ test("default http request with error", () => {
 	open.mockClear();
 	send.mockClear();
 });
+
+test("multiple http requests", () => {
+	let run = [false, false, false];
+	error = false;
+
+	Moon.use({
+		http: Moon.http.driver
+	});
+
+	Moon.run(() => ({
+		http: [{
+			url: "https://example.com/1",
+			onLoad: ({ http }) => {
+				run[0] = true;
+				expect(setRequestHeader).not.toBeCalled();
+				expect(open).toBeCalledWith("GET", "https://example.com/1");
+				expect(send).toBeCalledWith(null);
+				expect(http).toEqual({
+					status: 200,
+					headers: {"content-length": "1084", "date": "Fri, 25 Jun 04 00:00:00 +0000", "test": "moon"},
+					body: "Moon Test"
+				});
+				setRequestHeader.mockClear();
+				open.mockClear();
+				send.mockClear();
+				return {};
+			}
+		}, {
+			url: "https://example.com/2",
+			onLoad: ({ http }) => {
+				run[1] = true;
+				expect(setRequestHeader).not.toBeCalled();
+				expect(open).toBeCalledWith("GET", "https://example.com/2");
+				expect(send).toBeCalledWith(null);
+				expect(http).toEqual({
+					status: 200,
+					headers: {"content-length": "1084", "date": "Fri, 25 Jun 04 00:00:00 +0000", "test": "moon"},
+					body: "Moon Test"
+				});
+				setRequestHeader.mockClear();
+				open.mockClear();
+				send.mockClear();
+				return {};
+			}
+		}, {
+			url: "https://example.com/3",
+			onLoad: ({ http }) => {
+				run[2] = true;
+				expect(setRequestHeader).not.toBeCalled();
+				expect(open).toBeCalledWith("GET", "https://example.com/3");
+				expect(send).toBeCalledWith(null);
+				expect(http).toEqual({
+					status: 200,
+					headers: {"content-length": "1084", "date": "Fri, 25 Jun 04 00:00:00 +0000", "test": "moon"},
+					body: "Moon Test"
+				});
+				setRequestHeader.mockClear();
+				open.mockClear();
+				send.mockClear();
+				return {};
+			}
+		}]
+	}));
+
+	expect(run).toEqual([true, true, true]);
+
+	setRequestHeader.mockClear();
+	open.mockClear();
+	send.mockClear();
+});


### PR DESCRIPTION
The HTTP driver can send multiple concurrent requests, but can only
receive one at a time. If JavaScript were ever to get true parallelism,
one could use multiple HTTP drivers to account for multiple physical
network ports that could receive complete HTTP requests at the same
time. This adds tests for sending multiple requests and receiving them
individually.